### PR TITLE
Replace Threads in social blocklist

### DIFF
--- a/blocklists/social.json
+++ b/blocklists/social.json
@@ -17,7 +17,7 @@
   "reddit.com",
   "snapchat.com",
   "strava.com",
-  "threads.net",
+  "threads.com",
   "tinder.com",
   "tumblr.com",
   "twitter.com",


### PR DESCRIPTION
Meta stopped using threads.net a while ago.